### PR TITLE
During zero-shot generation, inter-event times may be dropped during evaluation.

### DIFF
--- a/EventStream/transformer/lightning_modules/zero_shot_evaluator.py
+++ b/EventStream/transformer/lightning_modules/zero_shot_evaluator.py
@@ -317,8 +317,12 @@ def zero_shot_evaluation(cfg: FinetuneConfig):
     num_dataloader_workers = cfg.optimization_config.num_dataloader_workers
 
     orig_max_seq_len = config.max_seq_len
+    orig_mean_log_inter_event_time = config.mean_log_inter_event_time_min
+    orig_std_log_inter_event_time = config.std_log_inter_event_time_min
     config.set_to_dataset(tuning_pyd)
     config.max_seq_len = orig_max_seq_len
+    config.mean_log_inter_event_time_min = orig_mean_log_inter_event_time
+    config.std_log_inter_event_time_min = orig_std_log_inter_event_time
 
     # Load the labeler
     labeler_fp = cfg.data_config.save_dir / "task_dfs" / f"{cfg.task_df_name}_labeler.py"

--- a/EventStream/transformer/model_output.py
+++ b/EventStream/transformer/model_output.py
@@ -964,7 +964,7 @@ class GenerativeSequenceModelSamples(ModelOutput):
         """
 
         if measurements_to_fill is None:
-            measurements_to_fill = []
+            measurements_to_fill = ["event_type"]
             for m, cfg in config.measurement_configs.items():
                 if not cfg.is_dropped and cfg.temporality == TemporalityType.DYNAMIC:
                     measurements_to_fill.append(m)


### PR DESCRIPTION
Additionally, when `measurements_to_fill` is None, it should still include `event_type`.