### PR TITLE
Replace use of list for cached_data and subject_ids in pytorch dataset with polars objects

### DIFF
--- a/EventStream/data/pytorch_dataset.py
+++ b/EventStream/data/pytorch_dataset.py
@@ -303,10 +303,9 @@ class PytorchDataset(SaveableMixin, SeedableMixin, TimeableMixin, torch.utils.da
             self.cached_data = self.cached_data.sample(seed=self.config.train_subset_seed, **kwargs)
 
         with self._time_as("convert_to_rows"):
-            self.subject_ids = self.cached_data["subject_id"].to_list()
+            self.subject_ids = self.cached_data["subject_id"]
             self.cached_data = self.cached_data.drop("subject_id")
             self.columns = self.cached_data.columns
-            self.cached_data = self.cached_data.rows()
 
     @staticmethod
     def _build_task_cached_df(task_df: pl.LazyFrame, cached_data: pl.LazyFrame) -> pl.LazyFrame:
@@ -479,7 +478,7 @@ class PytorchDataset(SaveableMixin, SeedableMixin, TimeableMixin, torch.utils.da
         output format.
         """
 
-        full_subj_data = {c: v for c, v in zip(self.columns, self.cached_data[idx])}
+        full_subj_data = {c: v for c, v in zip(self.columns, self.cached_data.row(idx))}
         for k in ["static_indices", "static_measurement_indices"]:
             if full_subj_data[k] is None:
                 full_subj_data[k] = []


### PR DESCRIPTION
This fixes the increased memory consumption issues when using multiple pytorch dataloaders (issue #73). It also dropped the starting memory usage in my test case from 30GB to 12GB. 

Removing this line makes all the difference: https://github.com/mmcdermott/EventStreamGPT/blob/b10e7415af1e9ea9517dfb52c343ae8155c40674/EventStream/data/pytorch_dataset.py#L309

Editing the following line didn't make much of a difference, but I edited it for consistency: 
https://github.com/mmcdermott/EventStreamGPT/blob/b10e7415af1e9ea9517dfb52c343ae8155c40674/EventStream/data/pytorch_dataset.py#L306

