### PR TITLE
Force foreign-key constraints among dfs

### DIFF
--- a/EventStream/data/dataset_polars.py
+++ b/EventStream/data/dataset_polars.py
@@ -633,6 +633,16 @@ class Dataset(DatasetBase[DF_T, INPUT_DF_T]):
                 dynamic_measurements_df, "measurement_id", TemporalityType.DYNAMIC, linked_ids
             )
 
+        if subjects_df is not None and events_df is not None:
+            subject_ids_set = set(subjects_df["subject_id"].to_list())
+            events_df = self._filter_col_inclusion(events_df, {"subject_id": subject_ids_set})
+
+        if events_df is not None and dynamic_measurements_df is not None:
+            event_ids_set = set(events_df["event_id"].to_list())
+            dynamic_measurements_df = self._filter_col_inclusion(
+                dynamic_measurements_df, {"event_id": event_ids_set}
+            )
+
         return subjects_df, events_df, dynamic_measurements_df
 
     @TimeableMixin.TimeAs


### PR DESCRIPTION
Force foreign-key constraints among dfs so that all the events in `events_df` have matched `subject_id`s with `subject_df`, and all the measurements in `dynamic_measurements_df` have matched `event_id`s with `events_df`.